### PR TITLE
fix: fix dictation of secondary variant in chip component

### DIFF
--- a/packages/ui/src/components/atoms/chip.tsx
+++ b/packages/ui/src/components/atoms/chip.tsx
@@ -12,7 +12,7 @@ const chipVariants = cva(
         danger: "bg-rose-500 hover:bg-rose-700   ",
         success: "bg-success hover:bg-emerald-700   ",
         info: "bg-sky-500 hover:bg-sky-700   ",
-        secendery: "bg-secondary hover:bg-zinc-900    ",
+        secondary: "bg-secondary hover:bg-zinc-900    ",
       },
       size: {
         sm: "h-9 text-sm",


### PR DESCRIPTION
fix dictation of secondary variant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a typographical error in the naming of a UI component variant, ensuring chip elements display with consistent styling and behavior across the application. Users may notice that items previously affected by misnaming now render as intended, enhancing overall consistency and visual experience. This minor correction aligns our design system standards and helps maintain uniform behavior in all UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->