### PR TITLE
fix: change navbar links to shadcn navigation menu components

### DIFF
--- a/apps/core/app/(landing)/_components/desktop-navbar/navbar-links.tsx
+++ b/apps/core/app/(landing)/_components/desktop-navbar/navbar-links.tsx
@@ -1,5 +1,12 @@
 import Link from "next/link";
 
+import {
+  NavigationMenu,
+  NavigationMenuItem,
+  NavigationMenuLink,
+  NavigationMenuList,
+  NavigationMenuTrigger,
+} from "@repo/ui/components/atoms/navigation-menu";
 import { Typography } from "@repo/ui/components/atoms/typography";
 
 import { useMegaMenuStore } from "./../../store/mega-menu";
@@ -15,14 +22,23 @@ const NavbarLinks = () => {
   };
 
   return (
-    <div className="flex items-center gap-4">
-      <Typography onClick={onClick} variant="label/sm">
-        Browse
-      </Typography>
-      <Link href="/become-auther" aria-label="become an author">
-        <Typography variant="label/sm">Become an author</Typography>
-      </Link>
-    </div>
+    <NavigationMenu>
+      <NavigationMenuList>
+        <NavigationMenuItem>
+          <NavigationMenuTrigger onClick={onClick}>
+            <Typography variant="label/sm">Browse</Typography>
+          </NavigationMenuTrigger>
+        </NavigationMenuItem>
+        <NavigationMenuItem>
+          <NavigationMenuLink
+            href="/become-auther"
+            aria-label="become an author"
+          >
+            <Typography variant="label/sm">Become an author</Typography>
+          </NavigationMenuLink>
+        </NavigationMenuItem>
+      </NavigationMenuList>
+    </NavigationMenu>
   );
 };
 

--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack --port 3000",
+    "dev": "next dev --turbopack --port 3001",
     "build": "next build && cd ../.. && pnpm format",
     "build:no-format": "next build",
     "start": "next start",

--- a/packages/ui/src/components/atoms/navigation-menu.tsx
+++ b/packages/ui/src/components/atoms/navigation-menu.tsx
@@ -7,7 +7,7 @@ import * as React from "react";
 import { cn } from "@repo/ui/lib/utils";
 
 const NavigationMenu = React.forwardRef<
-  React.ElementRef<typeof NavigationMenuPrimitive.Root>,
+  React.ComponentRef<typeof NavigationMenuPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Root>
 >(({ className, children, ...props }, ref) => (
   <NavigationMenuPrimitive.Root
@@ -25,7 +25,7 @@ const NavigationMenu = React.forwardRef<
 NavigationMenu.displayName = NavigationMenuPrimitive.Root.displayName;
 
 const NavigationMenuList = React.forwardRef<
-  React.ElementRef<typeof NavigationMenuPrimitive.List>,
+  React.ComponentRef<typeof NavigationMenuPrimitive.List>,
   React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.List>
 >(({ className, ...props }, ref) => (
   <NavigationMenuPrimitive.List
@@ -46,7 +46,7 @@ const navigationMenuTriggerStyle = cva(
 );
 
 const NavigationMenuTrigger = React.forwardRef<
-  React.ElementRef<typeof NavigationMenuPrimitive.Trigger>,
+  React.ComponentRef<typeof NavigationMenuPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Trigger>
 >(({ className, children, ...props }, ref) => (
   <NavigationMenuPrimitive.Trigger
@@ -64,7 +64,7 @@ const NavigationMenuTrigger = React.forwardRef<
 NavigationMenuTrigger.displayName = NavigationMenuPrimitive.Trigger.displayName;
 
 const NavigationMenuContent = React.forwardRef<
-  React.ElementRef<typeof NavigationMenuPrimitive.Content>,
+  React.ComponentRef<typeof NavigationMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Content>
 >(({ className, ...props }, ref) => (
   <NavigationMenuPrimitive.Content
@@ -81,7 +81,7 @@ NavigationMenuContent.displayName = NavigationMenuPrimitive.Content.displayName;
 const NavigationMenuLink = NavigationMenuPrimitive.Link;
 
 const NavigationMenuViewport = React.forwardRef<
-  React.ElementRef<typeof NavigationMenuPrimitive.Viewport>,
+  React.ComponentRef<typeof NavigationMenuPrimitive.Viewport>,
   React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Viewport>
 >(({ className, ...props }, ref) => (
   <div className={cn("absolute left-0 top-full flex justify-center")}>
@@ -99,7 +99,7 @@ NavigationMenuViewport.displayName =
   NavigationMenuPrimitive.Viewport.displayName;
 
 const NavigationMenuIndicator = React.forwardRef<
-  React.ElementRef<typeof NavigationMenuPrimitive.Indicator>,
+  React.ComponentRef<typeof NavigationMenuPrimitive.Indicator>,
   React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Indicator>
 >(({ className, ...props }, ref) => (
   <NavigationMenuPrimitive.Indicator


### PR DESCRIPTION
## Description

<!-- Brief description of changes -->

## Changes

-
-

## Checks

- [ ] Storybook updated
- [ ] Build succeeds
- [ ] Standards followed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Desktop navbar rebuilt with a semantic navigation menu, improving accessibility and consistency.
  - “Browse” now triggers the menu while closing the cart for smoother interaction.
  - “Become an author” link includes an accessible label and direct navigation.
  - No changes to how users access the navbar overall.
- Chores
  - Development server now runs on port 3001 instead of 3000.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->